### PR TITLE
CORS問題解決.localhost:3000からのリクエストができるようになった

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -37,11 +37,13 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'corsheaders',
 ]
 
 X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -135,3 +137,8 @@ MDEDITOR_CONFIGS = {
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# フロントで通信したいURLを記入
+CORS_ORIGIN_WHITELIST = [
+    'http://localhost:3000',
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ chardet==4.0.0
 dj-database-url==0.5.0
 Django==4.0.6
 django-cleanup==5.1.0
+django-cors-headers==3.13.0
 django-environ==0.5.0
 django-filter==22.1
 django-heroku==0.3.1


### PR DESCRIPTION
django-cors-headersをinstall
localhost:3000からのリクエストを受け付けるようになった